### PR TITLE
Use JS Config vars instead of hook

### DIFF
--- a/SkinEvelution.php
+++ b/SkinEvelution.php
@@ -104,6 +104,6 @@ class SkinEvelution extends SkinMustache {
 				'StickyRail' => $this->getConfig()->get( 'EvelutionStickyRail' ),
 				'Designer' => $this->getConfig()->get( 'EvelutionDesigner' ),
 			]
-		];
+		] );
 	}
 }

--- a/SkinEvelution.php
+++ b/SkinEvelution.php
@@ -88,23 +88,22 @@ class SkinEvelution extends SkinMustache {
 		$data["html-avatar"] = $avatarElement;
         return $data;
     }
-}
-
-
-
-class EvelutionHooks {
-	public static function onResourceLoaderGetConfigVars( array &$vars, string $skin, Config $config ) {
-		$vars['wgEvelution'] = [
-			'LeftPersonalLinks' => $config->get( 'EvelutionLeftPersonalLinks' ),
-			'DisableColorManagement' => $config->get( 'EvelutionDisableColorManagement' ),
-			'ForceOneHeader' => $config->get( 'EvelutionForceOneHeader' ),
-			'DisableRightRail' => $config->get( 'EvelutionDisableRightRail' ),
-			'ServerMode' => $config->get( 'EvelutionServerMode' ),
-			'CustomFont' => $config->get( 'EvelutionCustomFont' ),
-			'StickyRail' => $config->get( 'EvelutionStickyRail' ),
-			'Designer' => $config->get( 'EvelutionDesigner' ),
+	/**
+	 * @inheritDoc
+	 * @return array
+	 */
+	protected function getJsConfigVars(): array {
+		return array_merge( parent::getJsConfigVars(), [
+			'wgEvelution' => [
+				'LeftPersonalLinks' => $this->getConfig()->get( 'EvelutionLeftPersonalLinks' ),
+				'DisableColorManagement' => $this->getConfig()->get( 'EvelutionDisableColorManagement' ),
+				'ForceOneHeader' => $this->getConfig()->get( 'EvelutionForceOneHeader' ),
+				'DisableRightRail' => $this->getConfig()->get( 'EvelutionDisableRightRail' ),
+				'ServerMode' => $this->getConfig()->get( 'EvelutionServerMode' ),
+				'CustomFont' => $this->getConfig()->get( 'EvelutionCustomFont' ),
+				'StickyRail' => $this->getConfig()->get( 'EvelutionStickyRail' ),
+				'Designer' => $this->getConfig()->get( 'EvelutionDesigner' ),
+			]
 		];
-
-		return true;
 	}
 }

--- a/skin.json
+++ b/skin.json
@@ -18,8 +18,7 @@
   "manifest_version": 2,
 	"AutoloadClasses": {
 		"EvelutionSocialProfile": "SkinEvelution.php",
-		"SkinEvelution": "SkinEvelution.php",
-		"EvelutionHooks": "SkinEvelution.php"
+		"SkinEvelution": "SkinEvelution.php"
 	},
 	"config": {
 		"EvelutionLeftPersonalLinks": {
@@ -54,9 +53,6 @@
 			"value":false,
 			"description": "Enables theme Designer."
 		}
-	},
-	"Hooks": {
-		"ResourceLoaderGetConfigVars": "EvelutionHooks::onResourceLoaderGetConfigVars"
 	},
   "ValidSkinNames": {
     "evelution": {


### PR DESCRIPTION
This is one way. Another option would be a `packageFiles` callback to a certain function, allowing access to the variables from a single file.

This does make the config variables only available in this skin though, no longer globally across all skins, so will be usable client side still but only if using Evelution.