### PR TITLE
SECURITY.md: removed security advisories link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ Evelution releases supported. Every time a new Seasonal Release (Major) comes, t
 
 ## Reporting a Vulnerability
 
-To report a vulrenability, either open a [new security issue](https://github.com/AWikia/SkinEvelution/security/advisories/new) on this repo, or [message me](https://www.mediawiki.org/wiki/Special:EmailUser/Giorgos456) on mediawiki.org. Next:
+To report a vulrenability, [message me](https://www.mediawiki.org/wiki/Special:EmailUser/Giorgos456) on mediawiki.org. Next:
 - Give the security issue a proper name, describing what the security issue is. This is required or else it will be further be investigated.
 - You must describe accurately how to reproduce the issue. What instructions can the viewer take to experience the same issue you have found? Issues that cannot be reproduced easily will be further investigated with further attention by the user who reported it.
 - You must list what result you should **expect** and what result you get instead


### PR DESCRIPTION
Security advisories are only available for repository owners.