### PR TITLE
Avoid fatals in MediaWiki 1.43

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -12,7 +12,7 @@
   ],
   "type": "skin",
   "requires": {
-    "MediaWiki": ">= 1.37.0"
+    "MediaWiki": ">= 1.43.0"
   },
   "license-name": "GPL-3.0-or-later",
   "manifest_version": 2,
@@ -981,13 +981,13 @@
   },
   "ResourceModules": {
     "skins.evelution.styles": {
-      "class": "ResourceLoaderSkinModule",
+      "class": "MediaWiki\\ResourceLoader\\SkinModule",
       "features": {
         "normalize": true,
         "elements": true,
         "content-tables": true,
         "content-links": true,
-        "content-thumbnails": true,
+        "content-media": true,
         "interface-category": true,
         "toc": true
       },


### PR DESCRIPTION
* Class no longer exists
* Skin features have been deprecated and are about to be removed

Fixes: #118